### PR TITLE
Scanning for log4j 1 existence

### DIFF
--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -25,6 +25,10 @@ public class Log4j2Scanner {
 
 	private static final String JNDI_LOOKUP_CLASS_PATH = "org/apache/logging/log4j/core/lookup/JndiLookup.class";
 	private static final String LOG4j_CORE_POM_PROPS = "META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties";
+
+	private static final String LOG4j_12_CORE_POM_PROPS = "META-INF/maven/log4j/log4j/pom.properties";
+	private static final String LOG4j_12_JMSAPPENDER = "org/apache/log4j/net/JMSAppender.class";
+
 	private static final boolean isWindows = File.separatorChar == '\\';
 
 	private long scanDirCount = 0;
@@ -332,7 +336,7 @@ public class Log4j2Scanner {
 	}
 
 	private boolean isKernelFileSystem(String path) {
-		return (path.equals("/proc") || path.startsWith("/proc/")) || (path.equals("/sys") || path.startsWith("/sys/") || (path.equals("/dev") || path.startsWith("/dev/"));
+		return (path.equals("/proc") || path.startsWith("/proc/")) || (path.equals("/sys") || path.startsWith("/sys/") || (path.equals("/dev") || path.startsWith("/dev/")));
 	}
 
 	private void scanJarFile(File jarFile, boolean fix) {
@@ -346,6 +350,9 @@ public class Log4j2Scanner {
 			Status status = checkLog4jVersion(jarFile, fix, zipFile);
 			vulnerable = (status != Status.NOT_VULNERABLE);
 			needFix = (status == Status.VULNERABLE);
+
+			Status status_12 = checkLog4j_12_Version(jarFile, zipFile);
+			vulnerable |= (status_12 != Status.NOT_VULNERABLE);
 
 			// scan nested jar files
 			Enumeration<?> e = zipFile.entries();
@@ -395,10 +402,43 @@ public class Log4j2Scanner {
 		}
 	}
 
+	private Status checkLog4j_12_Version(File jarFile, ZipFile zipFile) throws IOException {
+		ZipEntry entry = zipFile.getEntry(LOG4j_12_CORE_POM_PROPS);
+		if (entry == null) {
+			return Status.NOT_VULNERABLE;
+		}
+
+		InputStream is = null;
+		try {
+			is = zipFile.getInputStream(entry);
+
+			String version = loadVulnerableLog4jVersion_12(is);
+			if (version != null) {
+				boolean jmsAppender = zipFile.getEntry(LOG4j_12_JMSAPPENDER) != null;
+				if(jmsAppender) {
+					String path = jarFile.getAbsolutePath();
+					printDetection_12(path, version, false);
+				}
+				return jmsAppender ? Status.NOT_VULNERABLE : Status.VULNERABLE;
+			}
+
+			return Status.NOT_VULNERABLE;
+		} finally {
+			ensureClose(is);
+		}
+	}
+
 	private void printDetection(String path, String version, boolean mitigated) {
-		String msg = "[*] Found CVE-2021-44228 vulnerability in " + path + ", log4j " + version;
+		String msg = "[*] Found CVE-2021-44228 (log4j 2.x) vulnerability in " + path + ", log4j " + version;
 		if (mitigated)
 			msg += " (mitigated)";
+
+		System.out.println(msg);
+	}
+
+	private void printDetection_12(String path, String version, boolean potential) {
+		String msg = potential ? "[?]" : "[*]";
+		msg += " Found CVE-2021-4104  (log4j 1.2) vulnerability in " + path + ", log4j " + version;
 
 		System.out.println(msg);
 	}
@@ -408,7 +448,9 @@ public class Log4j2Scanner {
 		ZipInputStream zis = null;
 
 		String vulnerableVersion = null;
+		String vulnerableVersion_12 = null;
 		boolean mitigated = true;
+		boolean foundJmsAppender = false;
 
 		try {
 			is = zipFile.getInputStream(zipEntry);
@@ -424,12 +466,25 @@ public class Log4j2Scanner {
 
 				if (entry.getName().equals(JNDI_LOOKUP_CLASS_PATH))
 					mitigated = false;
+
+				//1.2
+				if(entry.getName().equals(LOG4j_12_CORE_POM_PROPS)) {
+					vulnerableVersion_12 = loadVulnerableLog4jVersion_12(zis);
+				}
+				if(entry.getName().equals(LOG4j_12_JMSAPPENDER)) {
+					foundJmsAppender = true;
+				}
 			}
 
 			if (vulnerableVersion != null) {
 				String path = fatJarFile + " (" + zipEntry.getName() + ")";
 				printDetection(path, vulnerableVersion, mitigated);
 				return mitigated ? Status.MITIGATED : Status.VULNERABLE;
+			}
+			if(vulnerableVersion_12 != null && foundJmsAppender) {
+				String path = fatJarFile + " (" + zipEntry.getName() + ")";
+				printDetection_12(path, vulnerableVersion_12, false);
+				return Status.VULNERABLE;
 			}
 
 			return Status.NOT_VULNERABLE;
@@ -467,9 +522,19 @@ public class Log4j2Scanner {
 		return null;
 	}
 
+	private String loadVulnerableLog4jVersion_12(InputStream is) throws IOException {
+		Properties props = new Properties();
+		props.load(is);
+
+		String groupId = props.getProperty("groupId");
+		String artifactId = props.getProperty("artifactId");
+		String version = props.getProperty("version");
+		return version;
+	}
+
 	private boolean isScanTarget(String name) {
 		String loweredName = name.toLowerCase();
-		return loweredName.endsWith(".jar") || loweredName.endsWith(".war") || loweredName.endsWith(".ear");
+		return loweredName.endsWith(".jar") || loweredName.endsWith(".war") || loweredName.endsWith(".ear") || loweredName.endsWith(".zip") || loweredName.endsWith(".aar");
 	}
 
 	private boolean isVulnerable(int major, int minor, int patch) {


### PR DESCRIPTION
Hi,
it meight be useful to know if there is a log4j 1.x JAR in the classpath. It can also be vulnerabil if the JMSApender is used: https://access.redhat.com/security/cve/CVE-2021-4104

So we can get a list of log4j 1.x JARs still containing the JMSAppender.

„Copyright © 2021 Atruvia AG <opensource@atruvia.de>"