### PR TITLE
Extended scanning restore

### DIFF
--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -358,7 +358,7 @@ public class Log4j2Scanner {
 	}
 
 	private boolean isKernelFileSystem(String path) {
-		return (path.equals("/proc") || path.startsWith("/proc/")) || (path.equals("/sys") || path.startsWith("/sys/") || (path.equals("/dev") || path.startsWith("/dev/"));
+		return (path.equals("/proc") || path.startsWith("/proc/")) || (path.equals("/sys") || path.startsWith("/sys/") || (path.equals("/dev") || path.startsWith("/dev/")));
 	}
 
 	private void scanJarFile(File jarFile, boolean fix) {
@@ -520,7 +520,7 @@ public class Log4j2Scanner {
 
 	private boolean isScanTarget(String name) {
 		String loweredName = name.toLowerCase();
-		return loweredName.endsWith(".jar") || loweredName.endsWith(".war") || loweredName.endsWith(".ear");
+		return loweredName.endsWith(".jar") || loweredName.endsWith(".war") || loweredName.endsWith(".ear")|| loweredName.endsWith(".zip")|| loweredName.endsWith(".aar");
 	}
 
 	private boolean isVulnerable(int major, int minor, int patch) {

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -500,28 +500,6 @@ public class Log4j2Scanner {
 
 				scanJarFile(f, fix);
 			}
-			else if (path.replace('\\', '/').endsWith(LOG4j_CORE_POM_PROPS)) {
-				InputStream is = null;
-				try {
-					is = new FileInputStream(f);
-					String log4jVersion = loadVulnerableLog4jVersion(is);
-					if(log4jVersion != null) {
-						printDetection(path, log4jVersion, false, false);
-					}
-					vulnerableFileCount++;
-				}
-				catch (Exception e) {
-					System.err.println("Cannot read " + path);
-					e.printStackTrace();
-				}
-				finally {
-					ensureClose(is);
-				}
-			}
-			else if (path.replace('\\', '/').endsWith(JNDI_LOOKUP_CLASS_PATH)) {
-				printDetection(path, POTENTIALLY_VULNERABLE, false, true);
-				potentiallyVulnerableFileCount++;
-			}
 			else {
 				if (trace)
 					System.out.println("Skipping file: " + path);
@@ -604,7 +582,7 @@ public class Log4j2Scanner {
 	private Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
 		ZipEntry entry = zipFile.getEntry(LOG4j_CORE_POM_PROPS);
 		if (entry == null) {
-			//Check for existence of JndiLookup.class; e.g. somebady repacked the entries of the jars
+			//Check for existence of JndiLookup.class; e.g. somebody repacked the entries of the jars
 			entry = zipFile.getEntry(JNDI_LOOKUP_CLASS_PATH);
 			if(entry != null) {
 				String path = jarFile.getAbsolutePath();
@@ -647,7 +625,7 @@ public class Log4j2Scanner {
 
 		String vulnerableVersion = null;
 		boolean mitigated = true;
-		boolean foundJndiClass = false;
+		boolean pomFound = false;
 
 		try {
 			is = zipFile.getInputStream(zipEntry);
@@ -660,11 +638,11 @@ public class Log4j2Scanner {
 
 				if (entry.getName().equals(LOG4j_CORE_POM_PROPS)) {
 					vulnerableVersion = loadVulnerableLog4jVersion(zis);
+					pomFound = true;
 				}
 
 				if (entry.getName().equals(JNDI_LOOKUP_CLASS_PATH)) {
 					mitigated = false;
-					foundJndiClass = entry.getName().equals(LOG4j_CORE_POM_PROPS);
 				}
 			}
 
@@ -674,7 +652,7 @@ public class Log4j2Scanner {
 				return mitigated ? Status.MITIGATED : Status.VULNERABLE;
 			}
 
-			if(foundJndiClass) {
+			if(!mitigated && !pomFound) {
 				String path = fatJarFile + " (" + zipEntry.getName() + ")";
 				printDetection(path, POTENTIALLY_VULNERABLE, false, true);
 				return Status.POTENTIALLY_VULNERABLE;

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -365,7 +365,7 @@ public class Log4j2Scanner {
 
 				if (entry.getName().equals(JNDI_LOOKUP_CLASS_PATH)) {
 					mitigated = false;
-					foundJndiClass = true;
+					foundJndiClass = entry.getName().equals(LOG4j_CORE_POM_PROPS);
 				}
 			}
 

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -1,12 +1,6 @@
 package com.logpresso.scanner;
 
-import java.io.BufferedReader;
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Properties;
@@ -18,15 +12,17 @@ import java.util.zip.ZipOutputStream;
 
 public class Log4j2Scanner {
 	public enum Status {
-		NOT_VULNERABLE, VULNERABLE, MITIGATED
+		NOT_VULNERABLE, VULNERABLE, MITIGATED, POTENTIALLY_VULNERABLE
 	}
 
+	private static final String POTENTIALLY_VULNERABLE = "N/A - potentially vulnerable";
 	private static final String JNDI_LOOKUP_CLASS_PATH = "org/apache/logging/log4j/core/lookup/JndiLookup.class";
 	private static final String LOG4j_CORE_POM_PROPS = "META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties";
 	private long scanDirCount = 0;
 	private long scanFileCount = 0;
 	private long vulnerableFileCount = 0;
 	private long fixedFileCount = 0;
+	private long potentiallyVulnerableFileCount = 0;
 
 	private Set<File> vulnerableFiles = new LinkedHashSet<File>();
 
@@ -88,6 +84,7 @@ public class Log4j2Scanner {
 			System.out.println();
 			System.out.println("Scanned " + scanDirCount + " directories and " + scanFileCount + " files");
 			System.out.println("Found " + vulnerableFileCount + " vulnerable files");
+			System.out.println("Found " + potentiallyVulnerableFileCount + " potentially vulnerable files");
 			if (fix)
 				System.out.println("Fixed " + fixedFileCount + " vulnerable files");
 
@@ -232,7 +229,30 @@ public class Log4j2Scanner {
 					System.out.println("Scanning file: " + f.getAbsolutePath());
 
 				scanJarFile(f, fix);
-			} else {
+			}
+			else if (path.replace('\\', '/').endsWith(LOG4j_CORE_POM_PROPS)) {
+				InputStream is = null;
+				try {
+					is = new FileInputStream(f);
+					String log4jVersion = loadVulnerableLog4jVersion(is);
+					if(log4jVersion != null) {
+						printDetection(path, log4jVersion, false, false);
+					}
+					vulnerableFileCount++;
+				}
+				catch (Exception e) {
+					System.err.println("Cannot read " + path);
+					e.printStackTrace();
+				}
+				finally {
+					ensureClose(is);
+				}
+			}
+			else if (path.replace('\\', '/').endsWith(JNDI_LOOKUP_CLASS_PATH)) {
+				printDetection(path, POTENTIALLY_VULNERABLE, false, true);
+				potentiallyVulnerableFileCount++;
+			}
+			else {
 				if (trace)
 					System.out.println("Skipping file: " + f.getAbsolutePath());
 			}
@@ -244,12 +264,14 @@ public class Log4j2Scanner {
 		InputStream is = null;
 		boolean vulnerable = false;
 		boolean needFix = false;
+		boolean potentiallyVulnerable = false;
 		try {
 			zipFile = new ZipFile(jarFile);
 
 			Status status = checkLog4jVersion(jarFile, fix, zipFile);
-			vulnerable = (status != Status.NOT_VULNERABLE);
+			vulnerable = (status != Status.NOT_VULNERABLE && status != Status.POTENTIALLY_VULNERABLE && status != Status.POTENTIALLY_VULNERABLE);
 			needFix = (status == Status.VULNERABLE);
+			potentiallyVulnerable = (status == Status.POTENTIALLY_VULNERABLE);
 
 			// scan nested jar files
 			Enumeration<?> e = zipFile.entries();
@@ -257,8 +279,9 @@ public class Log4j2Scanner {
 				ZipEntry zipEntry = (ZipEntry) e.nextElement();
 				if (!zipEntry.isDirectory() && isScanTarget(zipEntry.getName())) {
 					Status nestedJarStatus = scanNestedJar(jarFile, zipFile, zipEntry);
-					vulnerable |= (nestedJarStatus != Status.NOT_VULNERABLE);
+					vulnerable |= (nestedJarStatus != Status.NOT_VULNERABLE && nestedJarStatus != Status.POTENTIALLY_VULNERABLE);
 					needFix |= (nestedJarStatus == Status.VULNERABLE);
+					potentiallyVulnerable |= (nestedJarStatus == Status.POTENTIALLY_VULNERABLE);
 				}
 			}
 
@@ -268,6 +291,9 @@ public class Log4j2Scanner {
 			if (fix && needFix)
 				vulnerableFiles.add(jarFile);
 
+			if(potentiallyVulnerable) {
+				potentiallyVulnerableFileCount++;
+			}
 		} catch (Throwable t) {
 			System.out.println("scan error: " + t.getMessage());
 		} finally {
@@ -278,8 +304,16 @@ public class Log4j2Scanner {
 
 	private Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
 		ZipEntry entry = zipFile.getEntry(LOG4j_CORE_POM_PROPS);
-		if (entry == null)
+		if (entry == null) {
+			//Check for existence of JndiLookup.class; e.g. somebady repacked the entries of the jars
+			entry = zipFile.getEntry(JNDI_LOOKUP_CLASS_PATH);
+			if(entry != null) {
+				String path = jarFile.getAbsolutePath();
+				printDetection(path, POTENTIALLY_VULNERABLE, false, true);
+				return Status.POTENTIALLY_VULNERABLE;
+			}
 			return Status.NOT_VULNERABLE;
+		}
 
 		InputStream is = null;
 		try {
@@ -289,7 +323,7 @@ public class Log4j2Scanner {
 			if (version != null) {
 				boolean mitigated = zipFile.getEntry(JNDI_LOOKUP_CLASS_PATH) == null;
 				String path = jarFile.getAbsolutePath();
-				printDetection(path, version, mitigated);
+				printDetection(path, version, mitigated, false);
 				return mitigated ? Status.MITIGATED : Status.VULNERABLE;
 			}
 
@@ -299,8 +333,9 @@ public class Log4j2Scanner {
 		}
 	}
 
-	private void printDetection(String path, String version, boolean mitigated) {
-		String msg = "[*] Found CVE-2021-44228 vulnerability in " + path + ", log4j " + version;
+	private void printDetection(String path, String version, boolean mitigated, boolean potential) {
+		String msg = potential ? "[?]" : "[*]";
+		msg += " Found CVE-2021-44228 vulnerability in " + path + ", log4j " + version;
 		if (mitigated)
 			msg += " (mitigated)";
 
@@ -313,6 +348,7 @@ public class Log4j2Scanner {
 
 		String vulnerableVersion = null;
 		boolean mitigated = true;
+		boolean foundJndiClass = false;
 
 		try {
 			is = zipFile.getInputStream(zipEntry);
@@ -323,17 +359,25 @@ public class Log4j2Scanner {
 				if (entry == null)
 					break;
 
-				if (entry.getName().equals(LOG4j_CORE_POM_PROPS))
+				if (entry.getName().equals(LOG4j_CORE_POM_PROPS)) {
 					vulnerableVersion = loadVulnerableLog4jVersion(zis);
+				}
 
-				if (entry.getName().equals(JNDI_LOOKUP_CLASS_PATH))
+				if (entry.getName().equals(JNDI_LOOKUP_CLASS_PATH)) {
 					mitigated = false;
+					foundJndiClass = true;
+				}
 			}
 
 			if (vulnerableVersion != null) {
 				String path = fatJarFile + " (" + zipEntry.getName() + ")";
-				printDetection(path, vulnerableVersion, mitigated);
+				printDetection(path, vulnerableVersion, mitigated, false);
 				return mitigated ? Status.MITIGATED : Status.VULNERABLE;
+			}
+			if(foundJndiClass) {
+				String path = fatJarFile + " (" + zipEntry.getName() + ")";
+				printDetection(path, POTENTIALLY_VULNERABLE, false, true);
+				return Status.POTENTIALLY_VULNERABLE;
 			}
 
 			return Status.NOT_VULNERABLE;

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -374,6 +374,7 @@ public class Log4j2Scanner {
 				printDetection(path, vulnerableVersion, mitigated, false);
 				return mitigated ? Status.MITIGATED : Status.VULNERABLE;
 			}
+
 			if(foundJndiClass) {
 				String path = fatJarFile + " (" + zipEntry.getName() + ")";
 				printDetection(path, POTENTIALLY_VULNERABLE, false, true);


### PR DESCRIPTION
Hi,

perhaps this is a good idea...
I extended the scanning engine that also "POTENTIALLY_VULNERABLE" files will be identified.
If "log4j-core/pom.properties" is NOT available in a JAR the scanner will check existence of "org/apache/logging/log4j/core/lookup/JndiLookup.class" -> then it is POTENTIALLY_VULNERABLE. It meight be useful if somebody repacked the JAR an does not include the pom.xml file.

Last but not least a simple classpath is also scanned; it will look for existence of the mentioned files in the directory (not packed in a JAR).

Have a look and feel free to change. Perhaps it is usefull.


Sorry - I deleted the first PR :-( (https://github.com/logpresso/CVE-2021-44228-Scanner/pull/22)