### PR TITLE
Prevents scanning process runtime directories

### DIFF
--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -332,7 +332,11 @@ public class Log4j2Scanner {
 	}
 
 	private boolean isKernelFileSystem(String path) {
-		return (path.equals("/proc") || path.startsWith("/proc/")) || (path.equals("/sys") || path.startsWith("/sys/") || (path.equals("/dev") || path.startsWith("/dev/"));
+		return (path.equals("/proc") || path.startsWith("/proc/")) || 
+		       (path.equals("/sys") || path.startsWith("/sys/")) || 
+			   (path.equals("/dev") || path.startsWith("/dev/")) || 
+			   (path.equals("/run") || path.startsWith("/run/")) || 
+			   (path.equals("/var/run") || path.startsWith("/var/run/"));
 	}
 
 	private void scanJarFile(File jarFile, boolean fix) {


### PR DESCRIPTION
This PR prevents scanning into runtime directories /run and /var/run/
It also includes fixes PR https://github.com/logpresso/CVE-2021-44228-Scanner/pull/43 