### PR TITLE
Added --help argument and implicitly enabled --report-csv when only --report-path is given

### DIFF
--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -151,6 +151,8 @@ public class Log4j2Scanner {
 		System.out.println("\tGenerate log4j2_scan_report_yyyyMMdd_HHmmss.csv in working directory");
 		System.out.println("--report-path");
 		System.out.println("\tSpecify report output path.");
+		System.out.println("--help");
+		System.out.println("\tPrint this help.");
 	}
 
 	private void parseArguments(String[] args) throws IOException {
@@ -171,6 +173,9 @@ public class Log4j2Scanner {
 				scanZip = true;
 			} else if (args[i].equals("--no-symlink")) {
 				noSymlink = true;
+			} else if (args[i].equals("--help") || args[i].equals("-h")) { //single letter argument interpreted only for convenience
+				pringUsage();
+				System.exit(0);
 			} else if (args[i].equals("--all-drives")) {
 				if (!isWindows)
 					throw new IllegalArgumentException("--all-drives is supported on Windows only.");

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -148,9 +148,9 @@ public class Log4j2Scanner {
 		System.out.println("--drives c,d");
 		System.out.println("\tScan specified drives on Windows. Spaces are not allowed here.");
 		System.out.println("--report-csv");
-		System.out.println("\tGenerate log4j2_scan_report_yyyyMMdd_HHmmss.csv in working directory");
+		System.out.println("\tGenerate log4j2_scan_report_yyyyMMdd_HHmmss.csv in working directory if not specified otherwise via --report-path [path]");
 		System.out.println("--report-path");
-		System.out.println("\tSpecify report output path.");
+		System.out.println("\tSpecify report output path. (Implies --report-csv)");
 		System.out.println("--help");
 		System.out.println("\tPrint this help.");
 	}
@@ -254,6 +254,7 @@ public class Log4j2Scanner {
 			} else if (args[i].equals("--report-csv")) {
 				reportCsv = true;
 			} else if (args[i].equals("--report-path")) {
+				reportCsv = true;
 				if (args.length > i + 1) {
 					String pattern = args[i + 1];
 					if (pattern.startsWith("--"))


### PR DESCRIPTION
Just some small housekeeping, to improve usability.

As described in the title I added the command line argument of --help (and -h just for good measure) 

I also thought it might be unnecessary to have two arguments for reporting into a file, so implicitly enabled --report-csv when --report-path is given. (I assume there will never be another output format...)