### PR TITLE
make scanJarFile and checkLog4jVersion public

### DIFF
--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -806,7 +806,7 @@ public class Log4j2Scanner {
 				|| (path.equals("/var/run") || path.startsWith("/var/run/"));
 	}
 
-	private void scanJarFile(File jarFile, boolean fix) {
+	public void scanJarFile(File jarFile, boolean fix) {
 		ZipFile zipFile = null;
 		InputStream is = null;
 		boolean vulnerable = false;
@@ -863,7 +863,7 @@ public class Log4j2Scanner {
 		}
 	}
 
-	private Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
+	public Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
 		ZipEntry entry = zipFile.getEntry(LOG4j_CORE_POM_PROPS);
 		if (entry == null) {
 			// Check for existence of JndiLookup.class; e.g. somebody repacked the entries

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -806,7 +806,7 @@ public class Log4j2Scanner {
 				|| (path.equals("/var/run") || path.startsWith("/var/run/"));
 	}
 
-	public void scanJarFile(File jarFile, boolean fix) {
+	protected void scanJarFile(File jarFile, boolean fix) {
 		ZipFile zipFile = null;
 		InputStream is = null;
 		boolean vulnerable = false;
@@ -863,7 +863,7 @@ public class Log4j2Scanner {
 		}
 	}
 
-	public Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
+	protected Status checkLog4jVersion(File jarFile, boolean fix, ZipFile zipFile) throws IOException {
 		ZipEntry entry = zipFile.getEntry(LOG4j_CORE_POM_PROPS);
 		if (entry == null) {
 			// Check for existence of JndiLookup.class; e.g. somebody repacked the entries


### PR DESCRIPTION
this would make it possible to override the functions in case one inherits the class