### PR TITLE
add JDK 8 build CI in addition to JDK 11 CI

### DIFF
--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         # 8 is the lowest java version for github runners
-        version: ['8', '11']
+        version: ['8', '11', '17']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.version }}

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -11,13 +11,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: true
+      matrix:
+        version: ['8', '11']
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: ${{ matrix.version }}
           distribution: 'temurin'
           architecture: x64
       - name: Download Maven

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         # 8 is the lowest java version for github runners
-        version: ['8', '11', '17']
+        version: ['8', '17']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # 8 is the lowest java version for github runners
         version: ['8', '11']
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ log4j2-scan is a single binary command-line tool for CVE-2021-44228 vulnerabilit
 ### How to use
 Just run log4j2-scan.exe or log4j2-scan with target directory path.
 
-The log4j2-scan.jar should work with JRE/JDK 7+
+The logpresso-log4j2-scan.jar should work with JRE/JDK 7+
 
 Usage
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ log4j2-scan is a single binary command-line tool for CVE-2021-44228 vulnerabilit
 ### How to use
 Just run log4j2-scan.exe or log4j2-scan with target directory path.
 
+The log4j2-scan.jar should work with JRE/JDK 7+
+
 Usage
 ```
 Logpresso CVE-2021-44228 Vulnerability Scanner 2.1.2 (2021-12-17)


### PR DESCRIPTION
this adds automated build testing for lowest JDK version (8) supported by utility that is available in GitHub action runners, as well as the highest JDK I could get to build successfully (11).