### PR TITLE
Clarify usage of --exclude-pattern and --exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Usage: log4j2-scan [--scan-log4j1] [--fix] target_path1 target_path2
 --no-symlink
         Do not detect symlink as vulnerable file.
 --exclude [path_prefix]
-        Exclude specified paths. You can specify multiple --exclude [path_prefix] pairs
+        Full paths of directories whose absolute path starts with the specified value will be excluded. Does not support relative paths. You can specify multiple --exclude [path_prefix] pairs
 --exclude-config [config_file_path]
         Specify exclude path list in text file. Paths should be separated by new line. Prepend # for comment.
 --exclude-pattern [pattern]
-        Exclude specified paths by pattern. You can specify multiple --exclude-pattern [pattern] pairs (non regex)
+        Exclude specified paths of directories by pattern. Supports fragments. You can specify multiple --exclude-pattern [pattern] pairs (non regex)
 --exclude-fs nfs,tmpfs
         Exclude paths by file system type. nfs, tmpfs, devtmpfs, and iso9660 is ignored by default.
 --report-csv

--- a/src/main/java/com/logpresso/scanner/Configuration.java
+++ b/src/main/java/com/logpresso/scanner/Configuration.java
@@ -70,13 +70,13 @@ public class Configuration {
 		System.out.println("--no-symlink");
 		System.out.println("\tDo not detect symlink as vulnerable file.");
 		System.out.println("--exclude [path_prefix]");
-		System.out.println("\tExclude specified paths. You can specify multiple --exclude [path_prefix] pairs");
+		System.out.println("\tFull paths of directories whose absolute path starts with the specified value will be excluded. Does not support relative paths. You can specify multiple --exclude [path_prefix] pairs");
 		System.out.println("--exclude-config [config_file_path]");
 		System.out.println(
 				"\tSpecify exclude path list in text file. Paths should be separated by new line. Prepend # for comment.");
 		System.out.println("--exclude-pattern [pattern]");
 		System.out.println(
-				"\tExclude specified paths by pattern. You can specify multiple --exclude-pattern [pattern] pairs (non regex)");
+				"\tExclude specified paths of directories by pattern. Supports fragments. You can specify multiple --exclude-pattern [pattern] pairs (non regex)");
 		System.out.println("--exclude-fs nfs,tmpfs");
 		System.out.println("\tExclude paths by file system type. nfs, tmpfs, devtmpfs, and iso9660 is ignored by default.");
 		System.out.println("--report-csv");


### PR DESCRIPTION
Both --exclude and --exclude-pattern have behaviors I found strange and wanted to update the readme.

--exclude usage is particularly confusing and should probably be rewritten. It does a string starts with and so doesn't know that `/my/path` is the same as `/my/./path`.


I would expect this to work with relative directories and files.

This creates problematic behavior when the path the user provided is `.`

Current behavior also does stuff that doesn't quite seem right:

```
Logpresso CVE-2021-44228 Vulnerability Scanner 2.3.1 (2021-12-19)
Scanning directory: log4jpoc (without EXPLOIT-CAPS.JAR)
[*] Found CVE-2021-44228 (log4j 2.x) vulnerability in C:\Users\weaston-ou\Downloads\log4jpoc\EXPLOIT-CAPS.JAR (log4j-core-2.10.0.jar), log4j 2.10.0
```