### PR TITLE
Ability to specify backup directory

### DIFF
--- a/src/main/java/com/logpresso/scanner/Configuration.java
+++ b/src/main/java/com/logpresso/scanner/Configuration.java
@@ -24,6 +24,7 @@ public class Configuration {
 	private boolean silent = false;
 	private boolean fix = false;
 	private boolean force = false;
+	private File backupDir = null;
 	private boolean scanZip = false;
 	private boolean noSymlink = false;
 	private boolean allDrives = false;
@@ -63,6 +64,8 @@ public class Configuration {
 				"\tWith --scan-log4j1 option, it also removes JMSAppender.class, SocketServer.class, SMTPAppender.class, SMTPAppender$1.class");
 		System.out.println("--force-fix");
 		System.out.println("\tDo not prompt confirmation. Don't use this option unless you know what you are doing.");
+		System.out.println("--backup-dir");
+		System.out.println("\tBackup destination directory. Defaults to being placed in the same dir as original.");
 		System.out.println("--all-drives");
 		System.out.println("\tScan all drives on Windows");
 		System.out.println("--drives c,d");
@@ -110,6 +113,10 @@ public class Configuration {
 			} else if (args[i].equals("--force-fix")) {
 				c.fix = true;
 				c.force = true;
+			}  else if (args[i].equals("--backup-dir")) {
+				verifyArgument(args, i, "Backup dir", "Specify backup directory.");
+				c.backupDir = new File(args[i + 1]);
+				i++;
 			} else if (args[i].equals("--debug")) {
 				c.debug = true;
 			} else if (args[i].equals("--trace")) {
@@ -378,6 +385,8 @@ public class Configuration {
 	public boolean isForce() {
 		return force;
 	}
+
+	public File getBackupDir() { return backupDir; }
 
 	public boolean isScanZip() {
 		return scanZip;

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -205,7 +205,16 @@ public class Log4j2Scanner {
 			if (config.isTrace())
 				System.out.printf("Patching %s%s%n", f.getAbsolutePath(), symlinkMsg);
 
-			File backupFile = new File(f.getAbsolutePath() + ".bak");
+			File backupFile;
+			File backupDir = config.getBackupDir();
+			if(backupDir != null){
+				File destDir = new File(backupDir, new File(f.getAbsolutePath().replace(":", "_drive")).getParent());
+				destDir.mkdirs();
+				backupFile = new File(destDir, f.getName());
+			}else{
+				backupFile = new File(f.getAbsolutePath() + ".bak");
+			}
+
 
 			if (backupFile.exists()) {
 				System.out.println("Error: Cannot create backup file. .bak File already exists. Skipping " + f.getAbsolutePath());

--- a/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
+++ b/src/main/java/com/logpresso/scanner/Log4j2Scanner.java
@@ -210,6 +210,11 @@ public class Log4j2Scanner {
 			if(backupDir != null){
 				File destDir = new File(backupDir, new File(f.getAbsolutePath().replace(":", "_drive")).getParent());
 				destDir.mkdirs();
+				if(!destDir.exists()||!destDir.isDirectory()) {
+					System.out.println("Error: Cannot create backup directory "+ destDir.getAbsolutePath()+". Skipping " + f.getAbsolutePath());
+					metrics.addErrorCount();
+					continue;
+				}
 				backupFile = new File(destDir, f.getName());
 			}else{
 				backupFile = new File(f.getAbsolutePath() + ".bak");


### PR DESCRIPTION
Original absolute path is "appended" to the destination backup folder. Column is replaced with "_drive". Not distinguishing between Windows and the rest. So Linux path or file name containing column might be renamed unnecessarily but seems like a reasonable tradeoff for simplicity.