### PR TITLE
Maven native image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,4 +39,32 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>native</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.8</version>
+						<extensions>true</extensions>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>build</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<imageName>${project.artifactId}</imageName>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/scanner.json
+++ b/scanner.json
@@ -1,4 +1,0 @@
-[
- { "name": "sun.nio.fs.WindowsFileAttributes", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredFields": true, "allDeclaredMethods": true, "allPublicMethods": true},
- { "name": "java.nio.file.attribute.DosFileAttributes", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredFields": true, "allDeclaredMethods": true, "allPublicMethods": true}
-]

--- a/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/native-image.properties
@@ -1,1 +1,2 @@
 Args = -H:-CheckToolchain -H:+AllowIncompleteClasspath -H:ReflectionConfigurationResources=${.}/reflection-config.json
+ImageName = log4j2-scan

--- a/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:-CheckToolchain -H:+AllowIncompleteClasspath -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/reflection-config.json
+++ b/src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner/reflection-config.json
@@ -1,0 +1,4 @@
+[
+  { "name": "sun.nio.fs.WindowsFileAttributes", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredFields": true, "allDeclaredMethods": true, "allPublicMethods": true},
+  { "name": "java.nio.file.attribute.DosFileAttributes", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredFields": true, "allDeclaredMethods": true, "allPublicMethods": true}
+]


### PR DESCRIPTION
Hi,

I was struggling with the generation of the native-image.
So I created a way to execute it via maven. `mvn package -Pnative` creates the JAR and the native image (for current OS). The command `man package` still creates only the JAR.

The configuration of the native image is now placed in `src/main/resources/META-INF/native-image/com.logpresso/log4j2-scanner`. It is the recommended way to provide [build in configurations](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#embedding-a-configuration-file). Also the reflection mappings (prior scanner.json is now placed here).
So also without maven the creation of the native image is always with the simple command `native-image -jar log4j2-scanner-2.3.2.jar` possible.

Please check out.
 