### PR TITLE
Upgrade commons-compress to avoid DoS issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.15</version>
+			<version>1.21</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
This is just a dependency update to avoid a bunch of CVEs in the apache-commons commons-compress library:

CVE-2019-12402
CVE-2021-35515
CVE-2021-35516
CVE-2021-35517
CVE-2021-36090
CVE-2018-11771
CVE-2018-1324