### PR TITLE
Fixes logpresso/CVE-2021-44228-Scanner#273

### DIFF
--- a/src/main/java/com/logpresso/scanner/Configuration.java
+++ b/src/main/java/com/logpresso/scanner/Configuration.java
@@ -35,6 +35,7 @@ public class Configuration {
 	private boolean scanForLogback = false;
 	private boolean noEmptyReport = false;
 	private boolean oldExitCode = false;
+	private boolean reportSecureVersions;
 	private Charset zipCharset = null;
 
 	private File restorePath = null;
@@ -139,6 +140,8 @@ public class Configuration {
 		System.out.println("\tSpecify csv log file path. If log file exists, log will be appended.");
 		System.out.println("--json-log-path");
 		System.out.println("\tSpecify json log file path. If log file exists, log will be appended.");
+		System.out.println("--reportSecureVersions");
+		System.out.println("\tReport also secure version in System.out and in report files.");
 		System.out.println("--old-exit-code");
 		System.out.println("\tReturn sum of vulnerable and potentially vulnerable files as exit code.");
 		System.out.println("--debug");
@@ -359,7 +362,10 @@ public class Configuration {
 				verifyArgument(args, i, "JSON Log path", "Specify JSON log output path.");
 				c.jsonLogPath = new File(args[i + 1]);
 				i++;
-			} else if (args[i].equals("--old-exit-code")) {
+			} else if(args[i].equals("--reportSecureVersions")) {
+				c.reportSecureVersions = true;
+			}
+			else if (args[i].equals("--old-exit-code")) {
 				c.oldExitCode = true;
 			} else if (args[i].equals("--throttle")) {
 				verifyArgument(args, i, "throttle", "Specify throttle number.");
@@ -643,6 +649,10 @@ public class Configuration {
 
 	public boolean isOldExitCode() {
 		return oldExitCode;
+	}
+
+	public boolean isReportSecureVersions() {
+		return reportSecureVersions;
 	}
 
 	public File getRestorePath() {

--- a/src/main/java/com/logpresso/scanner/Detector.java
+++ b/src/main/java/com/logpresso/scanner/Detector.java
@@ -345,6 +345,9 @@ public class Detector {
 					else
 						result.setVulnerable();
 				}
+				else {
+					printSafeLog4j2(jarFile, pathChain, log4j2Version);
+				}
 			} else if (!log4j2Mitigated) {
 				printDetectionForLog4j2(jarFile, pathChain, POTENTIALLY_VULNERABLE, false, true);
 				result.setPotentiallyVulnerableLog4j2();
@@ -362,8 +365,12 @@ public class Detector {
 				boolean vulnerable = true;
 				if (log4j1Version != null) {
 					vulnerable = isVulnerableLog4j1(Version.parse(log4j1Version));
-					if (vulnerable)
+					if (vulnerable) {
 						printDetectionForLog4j1(jarFile, pathChain, log4j1Version, log4j1Mitigated);
+					}
+					else {
+						printSafeLog4j1(jarFile, pathChain, log4j1Version);
+					}
 				} else {
 					printDetectionForLog4j1(jarFile, pathChain, POTENTIALLY_VULNERABLE, log4j1Mitigated);
 				}
@@ -376,10 +383,10 @@ public class Detector {
 				}
 			}
 
-			boolean logbackFound = isVulnerableLogback(logbackVersion, foundJndiUtil, foundEnvUtil);
+			boolean vulnerableLogbackFound = isVulnerableLogback(logbackVersion, foundJndiUtil, foundEnvUtil);
 			boolean logbackMitigated = !foundJndiUtil;
 
-			if (logbackFound) {
+			if (vulnerableLogbackFound) {
 				if (logbackVersion != null) {
 					printDetectionForLogback(jarFile, pathChain, logbackVersion, logbackMitigated);
 				} else {
@@ -508,9 +515,7 @@ public class Detector {
 
 	private void printDetectionForLog4j2(File jarFile, List<String> pathChain, String version, boolean mitigated,
 			boolean potential) {
-		String path = jarFile.getAbsolutePath();
-		if (pathChain != null && !pathChain.isEmpty())
-			path += " (" + StringUtils.toString(pathChain) + ")";
+		String path = getPath(jarFile, pathChain);
 
 		String msg = potential ? "[?]" : "[*]";
 
@@ -539,9 +544,7 @@ public class Detector {
 	}
 
 	private void printDetectionForLog4j1(File jarFile, List<String> pathChain, String version, boolean mitigated) {
-		String path = jarFile.getAbsolutePath();
-		if (pathChain != null && !pathChain.isEmpty())
-			path += " (" + StringUtils.toString(pathChain) + ")";
+		String path = getPath(jarFile, pathChain);
 
 		Version v = null;
 		if (!version.equals("N/A"))
@@ -567,9 +570,7 @@ public class Detector {
 	}
 
 	private void printDetectionForLogback(File jarFile, List<String> pathChain, String version, boolean mitigated) {
-		String path = jarFile.getAbsolutePath();
-		if (pathChain != null && !pathChain.isEmpty())
-			path += " (" + StringUtils.toString(pathChain) + ")";
+		String path = getPath(jarFile, pathChain);
 
 		String msg = "[?] Found CVE-2021-42550 (logback 1.2.7) vulnerability in " + path + ", logback " + version;
 		if (mitigated)
@@ -578,6 +579,29 @@ public class Detector {
 		System.out.println(msg);
 
 		addReport(jarFile, pathChain, "Logback", version, "CVE-2021-42550", mitigated, true);
+	}
+
+	private void printSafeLog4j1(File jarFile, List<String> pathChain, String version) {
+		if(config.isReportSecureVersions()) {
+			String path = getPath(jarFile, pathChain);
+			System.out.println("[-] Found safe version of 'Log4j 1' in " + path);
+			addSafeReport(jarFile, pathChain, "Log4j 1", version);
+		}
+	}
+
+	private void printSafeLog4j2(File jarFile, List<String> pathChain, String version) {
+		if(config.isReportSecureVersions()) {
+			String path = getPath(jarFile, pathChain);
+			System.out.println("[-] Found safe version of 'Log4j 2' in " + path);
+			addSafeReport(jarFile, pathChain, "Log4j 2", version);
+		}
+	}
+
+	private String getPath(File jarFile, List<String> pathChain) {
+		String path = jarFile.getAbsolutePath();
+		if (pathChain != null && !pathChain.isEmpty())
+			path += " (" + StringUtils.toString(pathChain) + ")";
+		return path;
 	}
 
 	public void addErrorReport(File jarFile, String error) {
@@ -635,4 +659,13 @@ public class Detector {
 		addErrorReport(jarFile, msg);
 	}
 
+	private void addSafeReport(File jarFile, List<String> pathChain, String product, String version) {
+		List<ReportEntry> entries = fileReports.get(jarFile);
+		if (entries == null) {
+			entries = new ArrayList<ReportEntry>();
+			fileReports.put(jarFile, entries);
+		}
+		ReportEntry entry = new ReportEntry(jarFile, StringUtils.toString(pathChain), product, version);
+		entries.add(entry);
+	}
 }

--- a/src/main/java/com/logpresso/scanner/ReportEntry.java
+++ b/src/main/java/com/logpresso/scanner/ReportEntry.java
@@ -23,6 +23,10 @@ public class ReportEntry {
 		this.error = error;
 	}
 
+	public ReportEntry(File path, String entry, String product, String version) {
+		this(path, entry, product, version, null, Status.NOT_VULNERABLE);
+	}
+
 	public ReportEntry(File path, String entry, String product, String version, String cve, Status status) {
 		this.path = path;
 		this.entry = entry;


### PR DESCRIPTION
Printed versions of secure versions

The safe version of log4j1.x and log4j2 will be printed on command line and also in the reports.
But only if parameter `--reportSecureVersions` is sepcified

"Copyright © 2021 Atruvia AG <opensource@atruvia.de>"