### PR TITLE
Fixes logpresso/CVE-2021-44228-Scanner#273

### DIFF
--- a/src/main/java/com/logpresso/scanner/Detector.java
+++ b/src/main/java/com/logpresso/scanner/Detector.java
@@ -605,25 +605,11 @@ public class Detector {
 		if (errorReports.size() < 100000)
 			errorReports.add(entry);
 
-		// invoke listeners
-		for (LogListener listener : logListeners) {
-			try {
-				listener.onError(entry);
-			} catch (Throwable t) {
-				// listener should not throw any exception
-				if (config.isDebug())
-					t.printStackTrace();
-			}
-		}
+		addReport(jarFile, entry);
 	}
 
 	private void addReport(File jarFile, List<String> pathChain, String product, String version, String cve, boolean mitigated,
 			boolean potential) {
-		List<ReportEntry> entries = fileReports.get(jarFile);
-		if (entries == null) {
-			entries = new ArrayList<ReportEntry>();
-			fileReports.put(jarFile, entries);
-		}
 
 		Status status = Status.VULNERABLE;
 		if (mitigated)
@@ -632,18 +618,7 @@ public class Detector {
 			status = Status.POTENTIALLY_VULNERABLE;
 
 		ReportEntry entry = new ReportEntry(jarFile, StringUtils.toString(pathChain), product, version, cve, status);
-		entries.add(entry);
-
-		// invoke listeners
-		for (LogListener listener : logListeners) {
-			try {
-				listener.onDetect(entry);
-			} catch (Throwable t) {
-				// listener should not throw any exception
-				if (config.isDebug())
-					t.printStackTrace();
-			}
-		}
+		addReport(jarFile, entry);
 	}
 
 	private void reportError(File jarFile, String msg) {
@@ -652,12 +627,26 @@ public class Detector {
 	}
 
 	private void addSafeReport(File jarFile, List<String> pathChain, String product, String version) {
+		ReportEntry entry = new ReportEntry(jarFile, StringUtils.toString(pathChain), product, version);
+		addReport(jarFile, entry);
+	}
+
+	private void addReport(File jarFile, ReportEntry reportEntry) {
 		List<ReportEntry> entries = fileReports.get(jarFile);
 		if (entries == null) {
 			entries = new ArrayList<ReportEntry>();
 			fileReports.put(jarFile, entries);
 		}
-		ReportEntry entry = new ReportEntry(jarFile, StringUtils.toString(pathChain), product, version);
-		entries.add(entry);
+		entries.add(reportEntry);
+		// invoke listeners
+		for (LogListener listener : logListeners) {
+			try {
+				listener.onDetect(reportEntry);
+			} catch (Throwable t) {
+				// listener should not throw any exception
+				if (config.isDebug())
+					t.printStackTrace();
+			}
+		}
 	}
 }


### PR DESCRIPTION
- Printed versions of secure versions - also with `--csv-log-path`
- Refactoring report creation

"Copyright © 2021 Atruvia AG <opensource@atruvia.de>"