### PR TITLE
add --fqdn  option for fully qualified local host name in reports.

### DIFF
--- a/src/main/java/com/logpresso/scanner/Configuration.java
+++ b/src/main/java/com/logpresso/scanner/Configuration.java
@@ -38,6 +38,7 @@ public class Configuration {
 	private boolean scanForLogback = false;
 	private boolean noEmptyReport = false;
 	private boolean oldExitCode = false;
+	private boolean useFQDN = false;
 	private Charset zipCharset = null;
 
 	private String apiKey = null;
@@ -160,6 +161,8 @@ public class Configuration {
 		System.out.println("\tDo not print progress message.");
 		System.out.println("--throttle");
 		System.out.println("\tLimit scan files per second.");
+		System.out.println("--fqdn");
+		System.out.println("\tUse fully qualified host name in reports.");
 		System.out.println("--help");
 		System.out.println("\tPrint this help.");
 	}
@@ -398,6 +401,8 @@ public class Configuration {
 				verifyArgument(args, i, "throttle", "Specify throttle number.");
 				c.throttle = Integer.parseInt(args[i + 1]);
 				i++;
+			} else if (args[i].equals("--fqdn")) {
+				c.useFQDN = true;
 			} else {
 				if (args[i].startsWith("-"))
 					throw new IllegalArgumentException("Unknown option: " + args[i]);
@@ -782,5 +787,9 @@ public class Configuration {
 
 	public int getThrottle() {
 		return throttle;
+	}
+
+	public boolean isFQDN() {
+		return useFQDN;
 	}
 }

--- a/src/main/java/com/logpresso/scanner/LogGenerator.java
+++ b/src/main/java/com/logpresso/scanner/LogGenerator.java
@@ -38,7 +38,7 @@ public class LogGenerator implements LogListener, Closeable {
 
 	public LogGenerator(Configuration config) throws IOException {
 		this.config = config;
-		this.hostname = IoUtils.getHostname(config.isDebug());
+		this.hostname = IoUtils.getHostname(config.isDebug(), config.isFQDN());
 
 		if (config.getUdpSyslogAddr() != null)
 			socket = new DatagramSocket();

--- a/src/main/java/com/logpresso/scanner/LogGenerator.java
+++ b/src/main/java/com/logpresso/scanner/LogGenerator.java
@@ -39,6 +39,9 @@ public class LogGenerator implements LogListener, Closeable {
 	public LogGenerator(Configuration config) throws IOException {
 		this.config = config;
 		this.hostname = IoUtils.getHostname(config.isDebug(), config.isFQDN());
+		if(config.isFQDN()){
+			System.out.println("Hostname: " + this.hostname);
+		}
 
 		if (config.getUdpSyslogAddr() != null)
 			socket = new DatagramSocket();

--- a/src/main/java/com/logpresso/scanner/ReportGenerator.java
+++ b/src/main/java/com/logpresso/scanner/ReportGenerator.java
@@ -182,7 +182,7 @@ public class ReportGenerator {
 				.format("\"Hostname\",\"Path\",\"Entry\",\"Product\",\"Version\",\"CVE\",\"Status\",\"Fixed\",\"Detected at\"%n");
 		csvStream.write(header.getBytes("utf-8"));
 
-		String hostname = IoUtils.getHostname(config.isDebug());
+		String hostname = IoUtils.getHostname(config.isDebug(), config.isFQDN());
 		if (hostname == null)
 			hostname = "";
 
@@ -256,7 +256,7 @@ public class ReportGenerator {
 			}
 		}
 
-		String hostname = IoUtils.getHostname(config.isDebug());
+		String hostname = IoUtils.getHostname(config.isDebug(), config.isFQDN());
 
 		JsonArray argArray = new JsonArray();
 		for (String arg : config.getArgs())

--- a/src/main/java/com/logpresso/scanner/utils/IoUtils.java
+++ b/src/main/java/com/logpresso/scanner/utils/IoUtils.java
@@ -24,15 +24,17 @@ public class IoUtils {
 		}
 	}
 
-	public static String getHostname(boolean debug) {
-		try {
-			String hostname = InetAddress.getLocalHost().getCanonicalHostName();
-			System.out.println("Hostname: " + hostname);
-		       	return hostname;
-    		} catch (Exception e) {
-			if (debug)
-			e.printStackTrace();
-    		}
+	public static String getHostname(boolean debug, boolean useFQDN) {
+		if(useFQDN) {
+			try {
+				String hostname = InetAddress.getLocalHost().getCanonicalHostName();
+				System.out.println("Hostname: " + hostname);
+		       		return hostname;
+    			} catch (Exception e) {
+				if (debug)
+				e.printStackTrace();
+    			}
+		}
 
 		// Try to fetch hostname without DNS resolving for closed network
 		boolean isWindows = File.separatorChar == '\\';

--- a/src/main/java/com/logpresso/scanner/utils/IoUtils.java
+++ b/src/main/java/com/logpresso/scanner/utils/IoUtils.java
@@ -28,11 +28,10 @@ public class IoUtils {
 		if(useFQDN) {
 			try {
 				String hostname = InetAddress.getLocalHost().getCanonicalHostName();
-				System.out.println("Hostname: " + hostname);
 		       		return hostname;
     			} catch (Exception e) {
 				if (debug)
-				e.printStackTrace();
+					e.printStackTrace();
     			}
 		}
 

--- a/src/main/java/com/logpresso/scanner/utils/IoUtils.java
+++ b/src/main/java/com/logpresso/scanner/utils/IoUtils.java
@@ -10,6 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.net.InetAddress;
 
 public class IoUtils {
 	public static File getJarDir() {
@@ -24,6 +25,15 @@ public class IoUtils {
 	}
 
 	public static String getHostname(boolean debug) {
+		try {
+			String hostname = InetAddress.getLocalHost().getCanonicalHostName();
+			System.out.println("Hostname: " + hostname);
+		       	return hostname;
+    		} catch (Exception e) {
+			if (debug)
+			e.printStackTrace();
+    		}
+
 		// Try to fetch hostname without DNS resolving for closed network
 		boolean isWindows = File.separatorChar == '\\';
 		if (isWindows) {


### PR DESCRIPTION
We have multiple sets of hosts with the matching ‘short’ hostnames but located in separate domains. in the default configuration the logpresso scanner detects the abbreviated host names as returned by the ‘uname -a’ command.  I've added the --fqdn flag to output full names in the reports to allow better tracking in multiple domain environments.    
